### PR TITLE
The Dependabot now supports pnpm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
-  # dependabot does not support pnpm yet.
-  # Track the issue: https://github.com/dependabot/dependabot-core/issues/1736
+  # Enable version updates for PNPM
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
But still missing the proper logic to implement security update support.
See: https://github.com/dependabot/dependabot-core/issues/7434